### PR TITLE
demoFix: demo中的动画用的参数Duration

### DIFF
--- a/Demo/YYKeyboardManagerDemo/ViewController.m
+++ b/Demo/YYKeyboardManagerDemo/ViewController.m
@@ -57,7 +57,7 @@
 #pragma mark - @protocol YYKeyboardObserver
 
 - (void)keyboardChangedWithTransition:(YYKeyboardTransition)transition {
-    [UIView animateWithDuration:transition.animationCurve delay:0 options:transition.animationOption animations:^{
+    [UIView animateWithDuration:transition.animationDuration delay:0 options:transition.animationOption animations:^{
         CGRect kbFrame = [[YYKeyboardManager defaultManager] convertRect:transition.toFrame toView:self.view];
         CGRect textframe = _textField.frame;
         textframe.size.width = kbFrame.size.width;


### PR DESCRIPTION
Demo里面的动画 
[UIView animateWithDuration:transition.animationCurve delay:0 options:transition.animationOption 
用的是transition.animationCurve，是不是输入错误？应该是用的transition.animationDuration的么？ 虽然显示上是没什么问题的。请问为什么会没问题呢？Debug的时候，transition.animationCurve 的值是7。transition.animationCurves 是0.25。
